### PR TITLE
When reading in IDL `.sav` files, intermediate data products were sav…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+install/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/PyFHD/pyfhd_tools/pyfhd_setup.py
+++ b/PyFHD/pyfhd_tools/pyfhd_setup.py
@@ -225,7 +225,7 @@ def _write_collated_yaml_config(pyfhd_config: dict, output_dir : str):
         for key in pyfhd_config.keys():
             ## These either a direct argument or are variables set internally to
             ## each run,so should not appear in the yaml
-            if key in ['top_level_dir', 'log_name', 'commit', 'obs_id', 'config_file', 'grid_psf_file_sav', 'grid_psf_file_npz']:
+            if key in ['top_level_dir', 'log_name', 'log_time', 'commit', 'obs_id', 'config_file', 'grid_psf_file_sav', 'grid_psf_file_npz']:
                 pass
             else:
                 if pyfhd_config[key] == None:
@@ -449,8 +449,6 @@ def pyfhd_setup(options : argparse.Namespace) -> Tuple[dict, logging.RootLogger]
 
     _write_collated_yaml_config(pyfhd_config, output_dir)
 
-    # shutil.copy(pyfhd_config['config_file'], Path(output_dir, pyfhd_config['log_name'] + '.yaml'))
-
     return pyfhd_config, logger
 
 def pyfhd_logger(pyfhd_config: dict) -> Tuple[logging.RootLogger, str]:
@@ -495,6 +493,7 @@ def pyfhd_logger(pyfhd_config: dict) -> Tuple[logging.RootLogger, str]:
         log_name = "pyfhd_" + pyfhd_config['description'].replace(' ', '_').lower() + '_' + log_time
     pyfhd_config['commit'] = commit
     pyfhd_config['log_name'] = log_name
+    pyfhd_config['log_time'] = log_time
     # Format the starting string for logging
     start_string = """\
     ________________________________________________________________________


### PR DESCRIPTION
…ed in `tmp_pyfhd` wherever the code was called from. Now, files are written to directory in top dir of outputs, and a time stamp is added, meaning concurrent runs should not interfere.