### PR TITLE
deepcopy fix

### DIFF
--- a/PyFHD/calibration/calibrate.py
+++ b/PyFHD/calibration/calibrate.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.typing import NDArray
+from copy import deepcopy
 from logging import Logger
 from PyFHD.calibration.calibration_utils import (
     vis_extract_autocorr, 
@@ -73,7 +74,9 @@ def calibrate(obs: dict, params: dict, vis_arr: NDArray[np.complex128], vis_weig
     if (pyfhd_config['flag_calibration']):
         logger.info("Flagging Calibration has been activated and calibration will now be flagged")
         obs = vis_calibration_flag(obs, cal, pyfhd_config, logger)
-    cal_base = cal.copy()
+
+    # Copy the cal structure with per-frequency gain solutions for future comparisons 
+    cal_base = deepcopy(cal)
 
     # Perform bandpass (amp + phase per fine freq) and polynomial fitting (low order amp + phase fit plus cable reflection fit)
     if (pyfhd_config["bandpass_calibrate"]):


### PR DESCRIPTION
# Copy cal fix

A bugfix to calibration.

In creating calibration plots (to be added in a future pull request) , it was found that the per-frequency solutions used for creating calibration residuals were being overwritten. Test not added -- doesn't seem like one exists for `calibrate.py`.

## Types of Changes
- [x] Bug Fixes
- [ ] New Feature(s)
- [ ] Breaking Changes
- [ ] Documentation
- [ ] Version Change
- [ ] Translation from FHD
- [ ] Build or CI Change

## Changelog

### Bug Fixes
* deepcopy the cal structure to create cal_base instead of regular copy. This preserves the calibration solutions in cal_base, which are used to create the calibration residuals. Calibration residuals are used to create diagnostic plots. 

### Dependency Changes
* deepcopy added to calibrate.py. deepcopy exists elsewhere in pyFHD

## Checklist

### General PR Checklist
  - [x] I have the read the contribution guide
  - [ ] Add all the above to the [Changelog](https://pyfhd.readthedocs.io/en/latest/changelog/changelog.html) into the unreleased section
### Existing Tests Checklist
  - [ ] If some tests fail and they are **meant** to, have they been changed? if so mention the exact tests that were changed and why here
  - [ ] Have the changes to existing tests been documented either through comments, changes to the docstring in ether the test or the associated functions?
### Bug Fixes Checklist
  - [x] Added all bug fixes with any issues associated with them linked.
  - [ ] Added new tests to cover bugs
  - [ ] Adjusted existing tests to cover bug, in which case check the [Existing Tests Checklist](#existing-tests-checklist)
### Documentation Checklist
  - [ ] The documentation is able to build successfully with any new changes and they are visible in your own build
### Version Checklist
  - [ ] Updated the changelog to put all the previous unreleased changelog into a version
  - [ ] Noted dependency changes since the last version 
### Build/CI 
  - [ ] Added a badge for any new CI actions or setups
  - [x] Existing badges remain unaffected, if not, document why in changelog

