### PR TITLE
Updates for renaming of F & K terms in pyuvdata

### DIFF
--- a/src/pyfhd/beam_setup/antenna.py
+++ b/src/pyfhd/beam_setup/antenna.py
@@ -116,8 +116,8 @@ def init_beam(obs: dict, pyfhd_config: dict, logger: Logger) -> dict:
         "gain": np.ones([n_ant_pol, freq_center.size, n_dipoles], dtype=np.float64),
         "coords": coords,
         "delays": delays,
-        "iresponse": None,
-        "projection": None,
+        "aligned_response": None,
+        "aligned_projection": None,
         # pyfhd supports one instrument at a time, so we setup the group so they're all in the same group.
         "group_id": np.zeros([n_ant_pol, obs["n_tile"]], dtype=np.int8),
         "pix_window": None,
@@ -291,15 +291,15 @@ def init_beam(obs: dict, pyfhd_config: dict, logger: Logger) -> dict:
     # Get the jones matrix for the antenna
     # shape is: (number of vector directions (usually 2), number of feeds (usually 2),
     # number of frequencies, number of directions on the sky)
-    antenna["iresponse"], antenna["projection"] = general_jones_matrix(
+    antenna["aligned_response"], antenna["aligned_projection"] = general_jones_matrix(
         beam,
         za_array=zenith_angle_arr.flatten(),
         az_array=azimuth_arr.flatten(),
         freq_array=freq_center,
         telescope_location=location,
     )
-    # remove the initial shallow dimension in iresponse
-    antenna["iresponse"] = antenna["iresponse"][0]
+    # remove the initial shallow dimension in aligned_response
+    antenna["aligned_response"] = antenna["aligned_response"][0]
 
     return antenna, psf, beam
 
@@ -435,12 +435,12 @@ def general_jones_matrix(
     noe_az_array[where_neg_az] = noe_az_array[where_neg_az] + np.pi * 2.0
 
     if isinstance(beam_obj, UVBeam):
-        f_obj, k_obj = beam_obj.decompose_feed_iresponse_projection()
+        f_obj, k_obj = beam_obj.decompose_feed_aligned_terms()
         f_beam = BeamInterface(f_obj)
         k_beam = BeamInterface(k_obj)
     else:
-        f_beam = BeamInterface(beam_obj, beam_type="feed_iresponse")
-        k_beam = BeamInterface(beam_obj, beam_type="feed_projection")
+        f_beam = BeamInterface(beam_obj, beam_type="feed_aligned_response")
+        k_beam = BeamInterface(beam_obj, beam_type="feed_aligned_projection")
 
     f_vals = f_beam.compute_response(
         az_array=noe_az_array,

--- a/src/pyfhd/beam_setup/beam_utils.py
+++ b/src/pyfhd/beam_setup/beam_utils.py
@@ -350,8 +350,8 @@ def beam_image_hyperresolved(
     # adjustments yourself.
     # baseline response (power beam) is product of the "two" antenna responses
     image_power_beam.flat[antenna["pix_use"]] = (
-        antenna["iresponse"][ant_pol_1, freq_i]
-        * np.conjugate(antenna["iresponse"][ant_pol_2, freq_i])
+        antenna["aligned_response"][ant_pol_1, freq_i]
+        * np.conjugate(antenna["aligned_response"][ant_pol_2, freq_i])
     ).flatten()
 
     # TODO: Work out the interpolation of the zenith power, it uses cubic interpolation


### PR DESCRIPTION
Updates the names of the feed aligned decomposition method and beam types after those names were updated in the pyuvdata branch. The branch hasn't been merged into pyuvdata yet, so this functionality hasn't fully solidified.

## Types of Changes
- [ ] Bug Fixes
- [ ] New Feature(s)
- [ ] Breaking Changes
- [ ] Documentation
- [ ] Version Change
- [ ] Translation from FHD
- [ ] Build or CI Change

## Checklist

### General PR Checklist
  - [x] I have the read the contribution guide
  - [ ] Add all the above to the [Changelog](https://pyfhd.readthedocs.io/en/latest/changelog/changelog.html) into the unreleased section
