### PR TITLE
make the axis order for beam pointers and uv planes match IDL FHD

### DIFF
--- a/src/pyfhd/beam_setup/antenna.py
+++ b/src/pyfhd/beam_setup/antenna.py
@@ -61,7 +61,7 @@ def init_beam(obs: dict, pyfhd_config: dict, logger: Logger) -> dict:
     tile_a = obs["baseline_info"]["tile_a"]
     tile_b = obs["baseline_info"]["tile_b"]
     ant_names = np.unique(
-        np.concatenate(tile_a[: obs["n_baselines"]], tile_b[: obs["n_baselines"]])
+        np.concatenate((tile_a[: obs["n_baselines"]], tile_b[: obs["n_baselines"]]))
     )
     if pyfhd_config["beam_offset_time"] is not None:
         jdate_use = obs["jd0"] + pyfhd_config["beam_offset_time"] / 24 / 3600

--- a/src/pyfhd/gridding/gridding_utils.py
+++ b/src/pyfhd/gridding/gridding_utils.py
@@ -45,11 +45,10 @@ def interpolate_kernel(
     kernel: NDArray[np.complex128]
         The interpolated 2D kernel
     """
-    # x_offset and y_offset needed to be swapped around as IDL is column-major, while Python is row-major
-    kernel = kernel_arr[y_offset, x_offset] * dx0dy0
-    kernel += kernel_arr[y_offset, x_offset + 1] * dx1dy0
-    kernel += kernel_arr[y_offset + 1, x_offset] * dx0dy1
-    kernel += kernel_arr[y_offset + 1, x_offset + 1] * dx1dy1
+    kernel = kernel_arr[x_offset, y_offset] * dx0dy0
+    kernel += kernel_arr[x_offset + 1, y_offset] * dx1dy0
+    kernel += kernel_arr[x_offset, y_offset + 1] * dx0dy1
+    kernel += kernel_arr[x_offset + 1, y_offset + 1] * dx1dy1
 
     return kernel
 
@@ -771,7 +770,7 @@ def visibility_count(
         ymin_use = ymin_iter[idx]
         # Please note that due to precision differences, the result will be different compared to IDL FHD
         uniform_filter[
-            ymin_use : ymin_use + psf_dim, xmin_use : xmin_use + psf_dim
+            xmin_use : xmin_use + psf_dim, ymin_use : ymin_use + psf_dim
         ] += bin_n[bin_i[bi]]
 
     if not no_conjugate:

--- a/src/pyfhd/gridding/visibility_grid.py
+++ b/src/pyfhd/gridding/visibility_grid.py
@@ -410,7 +410,7 @@ def visibility_grid(
                         box_mat = frequency_cache[fbin[ii]]
                     # For each visibility, calculate the kernel values on the static uv-grid given the
                     # hyperresolved kernel
-                    box_matrix[ii, :] = box_mat[y_off[ii], x_off[ii]]
+                    box_matrix[ii, :] = box_mat[x_off[ii], y_off[ii]]
 
         #  Calculate the conjugate transpose (dagger) of the uv-pixels that the current beam kernel contributes to
         box_matrix_dag = np.conj(box_matrix)
@@ -426,13 +426,13 @@ def visibility_grid(
                 np.transpose(box_matrix_dag), np.transpose(freq_i**2 / n_vis)
             )
             spectral_A[
-                ymin_use : ymin_use + psf_dim, xmin_use : xmin_use + psf_dim
+                xmin_use : xmin_use + psf_dim, ymin_use : ymin_use + psf_dim
             ].flat += term_A_box
             spectral_B[
-                ymin_use : ymin_use + psf_dim, xmin_use : xmin_use + psf_dim
+                xmin_use : xmin_use + psf_dim, ymin_use : ymin_use + psf_dim
             ].flat += term_B_box.real
             spectral_D[
-                ymin_use : ymin_use + psf_dim, xmin_use : xmin_use + psf_dim
+                xmin_use : xmin_use + psf_dim, ymin_use : ymin_use + psf_dim
             ].flat += term_D_box.real
             # del(term_A_box, term_B_box, term_D_box)
             if model is not None:
@@ -441,7 +441,7 @@ def visibility_grid(
                     np.transpose((freq_i * model_box) / n_vis),
                 )
                 spectral_model_A[
-                    ymin_use : ymin_use + psf_dim, xmin_use : xmin_use + psf_dim
+                    xmin_use : xmin_use + psf_dim, ymin_use : ymin_use + psf_dim
                 ] += term_Am_box
 
         if model is not None:
@@ -454,7 +454,7 @@ def visibility_grid(
                 np.transpose(box_matrix_dag), np.transpose(model_box / n_vis)
             )
             model_return[
-                ymin_use : ymin_use + psf_dim, xmin_use : xmin_use + psf_dim
+                xmin_use : xmin_use + psf_dim, ymin_use : ymin_use + psf_dim
             ].flat += box_arr
 
         # Calculate the product of the data vis and the beam kernel
@@ -464,7 +464,7 @@ def visibility_grid(
         vis_box = vis_box.flatten()
         box_arr = np.dot(np.transpose(box_matrix_dag), vis_box / n_vis)
         image_uv[
-            ymin_use : ymin_use + psf_dim, xmin_use : xmin_use + psf_dim
+            xmin_use : xmin_use + psf_dim, ymin_use : ymin_use + psf_dim
         ].flat += box_arr
         del box_arr
 
@@ -475,7 +475,7 @@ def visibility_grid(
                 np.transpose(box_matrix_dag), np.transpose(psf_weight / n_vis)
             )
             weights[
-                ymin_use : ymin_use + psf_dim, xmin_use : xmin_use + psf_dim
+                xmin_use : xmin_use + psf_dim, ymin_use : ymin_use + psf_dim
             ].flat += wts_box
 
         if pyfhd_config["grid_variance"]:
@@ -486,12 +486,12 @@ def visibility_grid(
                 np.transpose(psf_weight / n_vis),
             )
             variance[
-                ymin_use : ymin_use + psf_dim, xmin_use : xmin_use + psf_dim
+                xmin_use : xmin_use + psf_dim, ymin_use : ymin_use + psf_dim
             ].flat += var_box
 
         if uniform_flag:
             uniform_filter[
-                ymin_use : ymin_use + psf_dim, xmin_use : xmin_use + psf_dim
+                xmin_use : xmin_use + psf_dim, ymin_use : ymin_use + psf_dim
             ] += bin_n[bin_i[bi]]
 
         if verbose_logging and (

--- a/src/pyfhd/pyfhd_tools/test_utils.py
+++ b/src/pyfhd/pyfhd_tools/test_utils.py
@@ -255,6 +255,39 @@ def sav_file_vis_arr_swap_axes(sav_file_vis_arr: NDArray) -> NDArray:
     return vis_arr
 
 
+def sav_file_rearrange_psf(sav_psf):
+    """Reading in IDL psf structures via scipy.io.readsav results in rearranged
+    axes and badly sorted flattened arrays. Use this function to get fix them
+    for pyfhd.
+
+    Parameters
+    ----------
+    sav_psf : recarray
+        recarray as read in by scipy.io.readsav
+
+    Returns
+    -------
+    dict
+        Returns a psf dict with properly arranged arrays.
+    """
+    # do this first to drop beam_ptr size (for only 1 antenna type)
+    sav_psf["beam_ptr"][0] = sav_psf["beam_ptr"][0].T[:, :, 0]
+    sav_psf = recarray_to_dict(sav_psf)
+
+    # need to transpose the offset axes
+    sav_psf["beam_ptr"] = sav_psf["beam_ptr"].transpose([0, 1, 3, 2, 4])
+    # # finally need to reorder the last (flat) from f order to c order
+    inp_shape = sav_psf["beam_ptr"].shape
+    new_shape = tuple(list(inp_shape[:-1]) + [int(sav_psf["dim"]), int(sav_psf["dim"])])
+    sav_psf["beam_ptr"] = (
+        sav_psf["beam_ptr"].reshape(new_shape, order="F").reshape(inp_shape)
+    )
+
+    sav_psf["id"] = sav_psf["id"].astype(int).T
+
+    return sav_psf
+
+
 def print_types(dictionary: dict, dict_name: str, indent_level: int = 1) -> None:
     """
     When generating the tests, Sometimes I'd find it useful to see the types of all the keys and value pairs inside

--- a/tests/test_gridding/test_gridding_utils/test_interpolate_kernel.py
+++ b/tests/test_gridding/test_gridding_utils/test_interpolate_kernel.py
@@ -24,7 +24,13 @@ def interp_kernel_before(data_dir, number):
     interp_kernel_before = Path(data_dir, f"test_{number}_before_{data_dir.name}.h5")
 
     if interp_kernel_before.exists():
-        return interp_kernel_before
+        h5_before = load(interp_kernel_before, lazy_load=True)
+        after_axes_reorder = (
+            "after_axes_reorder" in h5_before.keys() and h5_before["after_axes_reorder"]
+        )
+        h5_before.close()
+        if after_axes_reorder:
+            return interp_kernel_before
 
     kernel_arr, x_offset, y_offset, dx0dy0, dx1dy0, dx0dy1, dx1dy1 = get_data_items(
         data_dir,
@@ -37,8 +43,9 @@ def interp_kernel_before(data_dir, number):
         f"visibility_grid_input_dx1dy1_{number}.npy",
     )
 
+    # transpose kernel as it was saved before the axis reordering to match IDL FHD
     h5_save_dict = {
-        "kernel_arr": kernel_arr,
+        "kernel_arr": kernel_arr.T,
         "x_offset": x_offset,
         "y_offset": y_offset,
         "dx0dy0": dx0dy0,
@@ -51,6 +58,7 @@ def interp_kernel_before(data_dir, number):
 
     save(interp_kernel_before, h5_save_dict, "before_file")
 
+    h5_save_dict["after_axes_reorder"] = True
     return interp_kernel_before
 
 

--- a/tests/test_gridding/test_gridding_utils/test_visibility_count.py
+++ b/tests/test_gridding/test_gridding_utils/test_visibility_count.py
@@ -81,13 +81,23 @@ def vis_count_after(data_dir, number):
     vis_count_after = Path(data_dir, f"test_{number}_after_{data_dir.name}.h5")
 
     if vis_count_after.exists():
-        return vis_count_after
+        h5_after = load(vis_count_after, lazy_load=True)
+        after_axes_reorder = (
+            "after_axes_reorder" in h5_after.keys() and h5_after["after_axes_reorder"]
+        )
+        h5_after.close()
+        if after_axes_reorder:
+            return vis_count_after
+
     uniform_filter = get_data_items(data_dir, f"output_uniform_filter_{number}.npy")
 
-    h5_save_dict = {"uniform_filter": uniform_filter}
+    # transpose uniform_filter as it was saved before the axis reordering to
+    # match IDL FHD
+    h5_save_dict = {"uniform_filter": uniform_filter.T}
 
     save(vis_count_after, h5_save_dict, "after_file")
 
+    h5_save_dict["after_axes_reorder"] = True
     return vis_count_after
 
 

--- a/tests/test_gridding/test_visibility_grid.py
+++ b/tests/test_gridding/test_visibility_grid.py
@@ -5,7 +5,7 @@ import numpy as np
 from os import environ as env
 from pathlib import Path
 from pyfhd.gridding.visibility_grid import visibility_grid
-from pyfhd.pyfhd_tools.test_utils import get_savs
+from pyfhd.pyfhd_tools.test_utils import get_savs, sav_file_rearrange_psf
 from pyfhd.io.pyfhd_io import save, load
 from logging import Logger
 from scipy.io import readsav
@@ -44,14 +44,53 @@ def before_gridding(data_dir: Path, number: int, request: pytest.FixtureRequest)
         )
     before_gridding = Path(data_dir, f"test_{number}_before_{data_dir.name}.h5")
 
-    if before_gridding.exists():
-        return before_gridding
+    sav_path = data_dir
+    if (
+        not Path(data_dir, f"input_{number}.sav").exists()
+        and env.get("PYFHD_TEST_PATH") is not None
+    ):
+        sav_path = Path(env.get("PYFHD_TEST_PATH"), "gridding", "visibility_grid")
 
-    h5_save_dict = get_savs(data_dir, f"input_{number}.sav")
-    # Subset the beam_ptr so we only take the first index of the baselines
-    # which contains the pointer for the rest of the baselines
-    h5_save_dict["psf"]["beam_ptr"][0] = h5_save_dict["psf"]["beam_ptr"][0].T[:, :, 0]
+    if before_gridding.exists():
+        h5_before = load(before_gridding, lazy_load=True)
+        after_axes_reorder = (
+            "after_axes_reorder" in h5_before.keys() and h5_before["after_axes_reorder"]
+        )
+        h5_before.close()
+        if after_axes_reorder:
+            return before_gridding
+        else:
+            # if the sav file doesn't exist, read in the h5 file and do the
+            # transposes by hand (required when relying only on zenodo test data)
+            if not Path(sav_path, f"input_{number}.sav").exists():
+                h5_before = load(before_gridding)
+                h5_before["psf"]["beam_ptr"] = h5_before["psf"]["beam_ptr"].transpose(
+                    [0, 1, 3, 2, 4]
+                )
+                inp_shape = h5_before["psf"]["beam_ptr"].shape
+                new_shape = tuple(
+                    list(inp_shape[:-1])
+                    + [int(h5_before["psf"]["dim"]), int(h5_before["psf"]["dim"])]
+                )
+                h5_before["psf"]["beam_ptr"] = (
+                    h5_before["psf"]["beam_ptr"]
+                    .reshape(new_shape, order="F")
+                    .reshape(inp_shape)
+                )
+                h5_before["psf"]["id"] = h5_before["psf"]["id"].astype(int).T
+
+                h5_before["after_axes_reorder"] = True
+                save(before_gridding, h5_before, "before_file")
+
+                return before_gridding
+
+    h5_save_dict = get_savs(sav_path, f"input_{number}.sav")
+
+    # fix the psf to be properly arranged
+    h5_save_dict["psf"] = sav_file_rearrange_psf(h5_save_dict["psf"])
+
     h5_save_dict = recarray_to_dict(h5_save_dict)
+
     h5_save_dict["uniform_flag"] = (
         True
         if ("uniform_filter" in h5_save_dict and h5_save_dict["uniform_filter"])
@@ -110,6 +149,8 @@ def before_gridding(data_dir: Path, number: int, request: pytest.FixtureRequest)
     else:
         if not isinstance(h5_save_dict["bi_use"], np.ndarray):
             h5_save_dict["bi_use"] = np.array([h5_save_dict["bi_use"]], dtype=np.int64)
+
+    h5_save_dict["after_axes_reorder"] = True
     save(before_gridding, h5_save_dict, "before_file")
 
     return before_gridding
@@ -123,10 +164,39 @@ def after_gridding(data_dir: Path, number: int, request: pytest.FixtureRequest):
         )
     after_gridding = Path(data_dir, f"test_{number}_after_{data_dir.name}.h5")
 
-    if after_gridding.exists():
-        return after_gridding
+    sav_path = data_dir
+    if (
+        not Path(data_dir, f"output_{number}.sav").exists()
+        and env.get("PYFHD_TEST_PATH") is not None
+    ):
+        sav_path = Path(env.get("PYFHD_TEST_PATH"), "gridding", "visibility_grid")
 
-    outputs = get_savs(data_dir, f"output_{number}.sav")
+    if after_gridding.exists():
+        h5_after = load(after_gridding, lazy_load=True)
+        after_axes_reorder = (
+            "after_axes_reorder" in h5_after.keys() and h5_after["after_axes_reorder"]
+        )
+        h5_after.close()
+        if after_axes_reorder:
+            return after_gridding
+        else:
+            # if the sav file doesn't exist, read in the h5 file and do the
+            # transposes by hand (required when relying only on zenodo test data)
+            if not Path(sav_path, f"input_{number}.sav").exists():
+                h5_after = load(after_gridding)
+                h5_after["image_uv"] = h5_after["image_uv"].T
+                h5_after["weights"] = h5_after["weights"].T
+                h5_after["variance"] = h5_after["variance"].T
+                h5_after["uniform_filter"] = h5_after["uniform_filter"].T
+                if "model_return" in h5_after.keys():
+                    h5_after["model_return"] = h5_after["model_return"].T
+
+                h5_after["after_axes_reorder"] = True
+                save(after_gridding, h5_after, "after_file")
+
+                return after_gridding
+
+    outputs = get_savs(sav_path, f"output_{number}.sav")
     # Delete the psf, we don't need it
     del outputs["psf"]
     del outputs["beam_arr"]
@@ -134,16 +204,17 @@ def after_gridding(data_dir: Path, number: int, request: pytest.FixtureRequest):
     outputs = recarray_to_dict(outputs)
 
     h5_save_dict = {
-        "image_uv": outputs["image_uv"],
-        "weights": outputs["weights"],
-        "variance": outputs["variance"],
-        "uniform_filter": outputs["uniform_filter"],
+        "image_uv": outputs["image_uv"].T,
+        "weights": outputs["weights"].T,
+        "variance": outputs["variance"].T,
+        "uniform_filter": outputs["uniform_filter"].T,
         "nf_vis": outputs["obs"]["nf_vis"],
     }
 
     if "model_return" in outputs:
-        h5_save_dict["model_return"] = outputs["model_return"]
+        h5_save_dict["model_return"] = outputs["model_return"].T
 
+    h5_save_dict["after_axes_reorder"] = True
     save(after_gridding, h5_save_dict, "after_file")
 
     return after_gridding
@@ -161,8 +232,6 @@ def test_visibility_grid(
         after_gridding = Path(data_dir, after_gridding.name)
     h5_before = load(before_gridding)
     h5_after = load(after_gridding)
-
-    h5_before["psf"]["id"] = h5_before["psf"]["id"].T
 
     # Format the indexing arrays if needed
     if h5_before["fi_use"] is not None and h5_before["fi_use"].size == 1:
@@ -226,12 +295,19 @@ def full_before_gridding(data_dir: Path, full_number: int):
     )
 
     if before_gridding.exists():
-        return before_gridding
+        h5_before = load(before_gridding, lazy_load=True)
+        after_axes_reorder = (
+            "after_axes_reorder" in h5_before.keys() and h5_before["after_axes_reorder"]
+        )
+        h5_before.close()
+        if after_axes_reorder:
+            return before_gridding
 
     h5_save_dict = get_savs(data_dir, f"full_size_input_{full_number}.sav")
-    # Subset the beam_ptr so we only take the first index of the baselines
-    # which contains the pointer for the rest of the baselines
-    h5_save_dict["psf"]["beam_ptr"][0] = h5_save_dict["psf"]["beam_ptr"][0].T[:, :, 0]
+
+    # fix the psf to be properly arranged
+    h5_save_dict["psf"] = sav_file_rearrange_psf(h5_save_dict["psf"])
+
     h5_save_dict = recarray_to_dict(h5_save_dict)
     h5_save_dict["uniform_flag"] = (
         True
@@ -293,6 +369,8 @@ def full_before_gridding(data_dir: Path, full_number: int):
     else:
         if not isinstance(h5_save_dict["bi_use"], np.ndarray):
             h5_save_dict["bi_use"] = np.array([h5_save_dict["bi_use"]], dtype=np.int64)
+
+    h5_save_dict["after_axes_reorder"] = True
     save(before_gridding, h5_save_dict, "before_file")
 
     return before_gridding
@@ -305,23 +383,30 @@ def full_after_gridding(data_dir: Path, full_number: int):
     )
 
     if after_gridding.exists():
-        return after_gridding
+        h5_after = load(after_gridding, lazy_load=True)
+        after_axes_reorder = (
+            "after_axes_reorder" in h5_after.keys() and h5_after["after_axes_reorder"]
+        )
+        h5_after.close()
+        if after_axes_reorder:
+            return after_gridding
 
     outputs = recarray_to_dict(
         get_savs(data_dir, f"full_size_output_{full_number}.sav")
     )
 
     h5_save_dict = {
-        "image_uv": outputs["image_uv"],
-        "weights": outputs["weights"],
-        "variance": outputs["variance"],
+        "image_uv": outputs["image_uv"].T,
+        "weights": outputs["weights"].T,
+        "variance": outputs["variance"].T,
         # 'uniform_filter': outputs['uniform_filter'],
         "nf_vis": outputs["obs"]["nf_vis"],
     }
 
     if "model_return" in outputs:
-        h5_save_dict["model_return"] = outputs["model_return"]
+        h5_save_dict["model_return"] = outputs["model_return"].T
 
+    h5_save_dict["after_axes_reorder"] = True
     save(after_gridding, h5_save_dict, "after_file")
 
     return after_gridding
@@ -330,8 +415,6 @@ def full_after_gridding(data_dir: Path, full_number: int):
 def test_full_visibility_grid(full_before_gridding: Path, full_after_gridding: Path):
     h5_before = load(full_before_gridding)
     h5_after = load(full_after_gridding)
-
-    # h5_before["psf"]["id"] = h5_before["psf"]["id"].T
 
     # Format the indexing arrays if needed
     if h5_before["fi_use"] is not None and h5_before["fi_use"].size == 1:
@@ -403,9 +486,53 @@ def before_vis_model_freq_gridding(tag, run, data_dir):
     before_file = Path(
         data_dir, f"{tag}_{run}_before_{data_dir.name}_vis_model_freq_split.h5"
     )
+
+    orig_beam_file = Path(
+        env.get("PYFHD_TEST_PATH"), "beams", "decomp_beam_pointing0.h5"
+    )
+    new_beam_file = Path(
+        env.get("PYFHD_TEST_PATH"), "beams", "decomp_beam_pointing0_transposed.h5"
+    )
+
     # If the h5 file already exists and has been created, return the path to it
-    if before_file.exists():
-        return before_file
+    if before_file.exists() and new_beam_file.exists():
+        h5_before = load(before_file, lazy_load=True)
+        after_axes_reorder = (
+            "after_axes_reorder" in h5_before.keys() and h5_before["after_axes_reorder"]
+        )
+        h5_before.close()
+        if after_axes_reorder:
+            return before_file
+
+    # do needed transpositions & reorderings on beam_ptr that were not originally
+    # done when it was translated to python & h5py
+    if not new_beam_file.exists():
+        psf = load(orig_beam_file, None, lazy_load=True)
+
+        transposed_beam = psf["beam_ptr"][()].transpose([0, 1, 3, 2, 4])
+        inp_shape = transposed_beam.shape
+        new_shape = tuple(
+            list(inp_shape[:-1]) + [int(psf["dim"][0]), int(psf["dim"][0])]
+        )
+        transposed_beam = transposed_beam.reshape(new_shape, order="F").reshape(
+            inp_shape
+        )
+        del psf
+
+        import shutil
+
+        shutil.copy(orig_beam_file, new_beam_file)
+
+        import h5py
+
+        with h5py.File(new_beam_file, "r+") as h5f:
+            del h5f["beam_ptr"]
+            h5f.create_dataset(
+                "beam_ptr",
+                data=transposed_beam,
+                dtype=np.complex128,
+                compression="gzip",
+            )
 
     sav_file = before_file.with_suffix(".sav")
 
@@ -428,11 +555,9 @@ def before_vis_model_freq_gridding(tag, run, data_dir):
     # Transpose the model if it exists
     if "model_ptr" in h5_save_dict and h5_save_dict["model_ptr"] is not None:
         h5_save_dict["model_ptr"] = h5_save_dict["model_ptr"].T
-    psf = load(
-        Path(env.get("PYFHD_TEST_PATH"), "beams", "decomp_beam_pointing0.h5"),
-        None,
-        lazy_load=True,
-    )
+
+    psf = load(new_beam_file, None, lazy_load=True)
+
     h5_save_dict["pyfhd_config"] = {
         "interpolate_kernel": psf["interpolate_kernel"][0],
         "psf_dim": psf["dim"][0],
@@ -484,6 +609,7 @@ def before_vis_model_freq_gridding(tag, run, data_dir):
         if not isinstance(h5_save_dict["bi_use"], np.ndarray):
             h5_save_dict["bi_use"] = np.array([h5_save_dict["bi_use"]], dtype=np.int64)
 
+    h5_save_dict["after_axes_reorder"] = True
     save(before_file, h5_save_dict, "before_file")
 
     return before_file
@@ -498,13 +624,24 @@ def after_vis_model_freq_gridding(tag, run, data_dir):
     )
     # If the h5 file already exists and has been created, return the path to it
     if after_file.exists():
-        return after_file
+        h5_after = load(after_file, lazy_load=True)
+        after_axes_reorder = (
+            "after_axes_reorder" in h5_after.keys() and h5_after["after_axes_reorder"]
+        )
+        h5_after.close()
+        if after_axes_reorder:
+            return after_file
 
     sav_file = after_file.with_suffix(".sav")
-    sav_dict = convert_sav_to_dict(str(sav_file), "faked")
-    sav_dict = recarray_to_dict(sav_dict)
+    h5_save_dict = convert_sav_to_dict(str(sav_file), "faked")
+    h5_save_dict = recarray_to_dict(h5_save_dict)
 
-    save(after_file, sav_dict, "after_file")
+    # transpose uv planes
+    for key in ["dirty_uv", "weights_holo", "variance_holo", "model_return"]:
+        h5_save_dict[key] = h5_save_dict[key].T
+
+    h5_save_dict["after_axes_reorder"] = True
+    save(after_file, h5_save_dict, "after_file")
 
     return after_file
 
@@ -520,7 +657,9 @@ def test_visibility_grid_in_vis_model_freq_split(
     h5_after = load(after_vis_model_freq_gridding)
 
     psf = load(
-        Path(env.get("PYFHD_TEST_PATH"), "beams", "decomp_beam_pointing0.h5"),
+        Path(
+            env.get("PYFHD_TEST_PATH"), "beams", "decomp_beam_pointing0_transposed.h5"
+        ),
         None,
         lazy_load=True,
     )


### PR DESCRIPTION
The original implementation had a number of places where the y direction axis came before the x direction axis (beam offsets, uv planes, etc). This was done because of the intrinsic difference in row/column ordering in python & IDL but the pyfhd team has decided that that is likely to lead to confusion and bugs in the long term.

This PR changes these orderings to put the x direction axis before the y direction axis throughout the beam and gridding code.

It also updates the tests, which requires a number of updates to test files, mostly transpositions of arrays. The most complicated situation is for psf beam_ptr when read out of an IDL save file because it is structured as many layers of pointer arrays. Each layer must be transposed separately and the lowest layer is a flattened array which must be unflattened with the Fortran order and then reflattened with the C order. All of the necessary restructurings for the psf structure was put into a function in `pyfhd_tools/test_utils.py`.


## Types of Changes
- [ ] Bug Fixes
- [ ] New Feature(s)
- [x] Breaking Changes
- [ ] Documentation
- [ ] Version Change
- [ ] Translation from FHD
- [ ] Build or CI Change

## Checklist

### General PR Checklist
  - [x] I have the read the contribution guide
  - [ ] Add all the above to the [Changelog](https://pyfhd.readthedocs.io/en/latest/changelog/changelog.html) into the unreleased section
  - [ ] The breaking changes have been noted in the change log
  - [ ] The breaking changes have been noted as a warning in any relevant tutorials in the documentation
  - [ ] The breaking changes have been noted as a warning in any relevant functions in the API documentation, this should be put under the Warnings section in the numpydoc for the associated functions, please note the version that the breaking change is **not** in. For example if the current version is 1.1 and you make the breaking change for it to be in version 1.2, say there has been a breaking change for versions <=1.1 and indicate what the change is.
