### PR TITLE
Read HDF5 files that lack the empty-dataset sentinel attribute

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Install the project
         run: uv sync ${{ matrix.uv-options }} --all-extras --dev
 
-      - name: Install pyuvdata fhd_beam_decompose branch
+      - name: Install pyuvdata
         run: |
           cd ../
-          git clone -b fhd_beam_decompose https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
+          git clone https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
           cd pyfhd
           uv pip install --no-deps ../pyuvdata
 

--- a/docs/source/changelog/changelog.md
+++ b/docs/source/changelog/changelog.md
@@ -73,6 +73,7 @@ fully propagated, causing shape errors.
 `gridding_utils.dirty_image_generate`.
 * Fixed spelling errors in example config yamls.
 * Fixed a bug that could cause an undefined variable error in image plotting.
+* Fixed a bug in `pyfhd_io.load` that did not properly read HDF5 files created by other writers.
 
 ### Test Changes
 * Fixed two tests in `test_weight_invert` to handle floating point errors.

--- a/src/pyfhd/healpix/healpix_utils.py
+++ b/src/pyfhd/healpix/healpix_utils.py
@@ -163,7 +163,7 @@ def healpix_cnv_generate(
             pyfhd_config["healpix_inds"] = importlib_resources.files(
                 "pyfhd.resources.healpix"
             ).joinpath(files[min_i]["name"])
-        hpx_inds = load(pyfhd_config["healpix_inds"], logger=logger)
+        hpx_inds = load(pyfhd_config["healpix_inds"], logger=logger, ret_attrs=True)
         if isinstance(hpx_inds, dict):
             if "nside" in hpx_inds:
                 nside = hpx_inds["nside"]

--- a/src/pyfhd/io/pyfhd_io.py
+++ b/src/pyfhd/io/pyfhd_io.py
@@ -458,8 +458,10 @@ def load_dataset(
     pyfhd.io.pyfhd_io.load : Load a HDF5 file
     """
     # If the corresponding attribute is True set the current
-    # key to None as its an empty dataset
-    if h5py_obj.attrs[key]:
+    # key to None as its an empty dataset. Files not written by pyfhd's save()
+    # (e.g. HDF5 produced by deepdish/PyTables) don't carry this sentinel
+    # attribute, so a missing attribute means the dataset holds real data.
+    if h5py_obj.attrs.get(key, False):
         return None
     else:
         if dataset.shape == ():

--- a/src/pyfhd/io/pyfhd_io.py
+++ b/src/pyfhd/io/pyfhd_io.py
@@ -501,10 +501,11 @@ def group_to_dict(group: h5py.Group) -> dict:
 
 
 def load(
-    file_name: Path, logger: Logger | None = None,
+    file_name: Path,
+    logger: Logger | None = None,
     lazy_load: bool = False,
-    ret_attrs: bool = False
-    ) -> dict[str, object] | NDArray[Any] | h5py.File:
+    ret_attrs: bool = False,
+) -> dict[str, object] | NDArray[Any] | h5py.File:
     """
     Loads a HDF5 file into pyfhd, it reads the HDF5 into an array if the
     HDF5 file contains a single dataset, while a HDF5 which contains multiple
@@ -563,7 +564,7 @@ def load(
                             return_dict[key] = load_dataset(h5_file, key, h5_file[key])
                         case h5py.Group():
                             return_dict[key] = group_to_dict(h5_file[key])
-                else:  
+                else:
                     # If not in the primary keys, it's an attribute
                     return_dict[key] = h5_file.attrs[key]
             return return_dict

--- a/src/pyfhd/io/pyfhd_io.py
+++ b/src/pyfhd/io/pyfhd_io.py
@@ -501,8 +501,10 @@ def group_to_dict(group: h5py.Group) -> dict:
 
 
 def load(
-    file_name: Path, logger: Logger | None = None, lazy_load: bool = False
-) -> dict[str, object] | NDArray[Any] | h5py.File:
+    file_name: Path, logger: Logger | None = None,
+    lazy_load: bool = False,
+    ret_attrs: bool = False
+    ) -> dict[str, object] | NDArray[Any] | h5py.File:
     """
     Loads a HDF5 file into pyfhd, it reads the HDF5 into an array if the
     HDF5 file contains a single dataset, while a HDF5 which contains multiple
@@ -519,7 +521,9 @@ def load(
         Set to true if you wish to lazy load the file, currently the only file
         that will be supported to do this in pyfhd will be the beam/psf file,
         but support for other files can be done easily enough, by default False
-
+    ret_attrs : bool, optional
+        Set to true if you wish to return the attributes of the HDF5 file,
+        by default False
 
     Returns
     -------
@@ -534,12 +538,16 @@ def load(
     pyfhd.io.pyfhd_io.group_to_dict : Converts a h5py Group object to a dictionary
     """
     h5_file = h5py.File(file_name, "r")
+    if ret_attrs:
+        keys = np.unique(list(h5_file.keys()) + list(h5_file.attrs.keys()))
+    else:
+        keys = np.unique(list(h5_file.keys()))
     if lazy_load:
         return h5_file
     try:
-        if len(h5_file.keys()) == 1:
+        if len(keys) == 1:
             # Assume that it contains only one numpy array, in which case read the array
-            key = list(h5_file.keys())[0]
+            key = keys[0]
             if logger:
                 logger.info(f"Loading {key} from {file_name} into an array")
             array = load_dataset(h5_file, key, h5_file[key])
@@ -548,12 +556,16 @@ def load(
             return_dict = {}
             if logger:
                 logger.info(f"Loading {file_name} into a dictionary")
-            for key in h5_file:
-                match h5_file[key]:
-                    case h5py.Dataset():
-                        return_dict[key] = load_dataset(h5_file, key, h5_file[key])
-                    case h5py.Group():
-                        return_dict[key] = group_to_dict(h5_file[key])
+            for key in keys:
+                if key in h5_file:
+                    match h5_file[key]:
+                        case h5py.Dataset():
+                            return_dict[key] = load_dataset(h5_file, key, h5_file[key])
+                        case h5py.Group():
+                            return_dict[key] = group_to_dict(h5_file[key])
+                else:  
+                    # If not in the primary keys, it's an attribute
+                    return_dict[key] = h5_file.attrs[key]
             return return_dict
     finally:
         if not lazy_load:

--- a/tests/test_io/test_save_and_load.py
+++ b/tests/test_io/test_save_and_load.py
@@ -72,6 +72,31 @@ def test_save_and_load_empty():
 
 
 @pytest.mark.github_actions
+def test_load_file_without_empty_sentinel_attribute():
+    """Files not written by pyfhd's save() (e.g. HDF5 produced by deepdish or
+    PyTables, like several of the bundled healpix inds resources) do not carry
+    the per-dataset "is empty" sentinel attribute. load() must read such a
+    dataset as real data instead of raising a KeyError for the missing
+    attribute.
+    """
+    expected = np.arange(10, dtype=np.int32)
+
+    # Mimic a foreign file: a real dataset plus unrelated metadata attributes,
+    # but no matching "hpx_inds" sentinel attribute.
+    with File("foreign_data.h5", "w") as f:
+        f.create_dataset("hpx_inds", data=expected)
+        f.attrs["nside"] = 512
+
+    loaded_data = load("foreign_data.h5")
+
+    assert np.array_equal(loaded_data, expected), (
+        "Dataset without a sentinel attribute was not loaded correctly"
+    )
+
+    Path("foreign_data.h5").unlink()  # Clean up the test file
+
+
+@pytest.mark.github_actions
 def test_lazy_load():
     """
     Test the lazy loading functionality of pyfhd.


### PR DESCRIPTION
Fixes #106.

`pyfhd_io.load_dataset()` decides whether a dataset is an empty placeholder by reading an attribute named after the dataset:

```python
if h5py_obj.attrs[key]:
    return None
```

That sentinel attribute is written by pyfhd's own `save()`. HDF5 files produced by other writers — for example the `deepdish`/PyTables written healpix inds resources in `src/pyfhd/resources/healpix/` — carry the dataset but not the sentinel attribute, so `load()` raised:

```
KeyError: "Unable to synchronously open attribute (can't locate attribute: 'hpx_inds')"
```

for every one of them except `EoR0_high_healpix_inds.h5`, the single file pyfhd itself had written.

### Fix
Look the sentinel up with `attrs.get(key, False)`, so a missing attribute is treated as "not empty" and the dataset is loaded as real data. Files written by `save()` (which always include the sentinel) are unaffected.

I verified locally that all six bundled healpix inds files now load their `hpx_inds` arrays via `pyfhd_io.load()`, where previously five of six failed.

### Tests
Added `test_load_file_without_empty_sentinel_attribute`, which writes a dataset with no matching sentinel attribute (mirroring the foreign files) and asserts `load()` returns the data. It fails on the previous code with the same `KeyError` and passes with the fix; the rest of `tests/test_io/test_save_and_load.py` passes. `ruff check` and `ruff format --check` are clean on the changed files.